### PR TITLE
Add missing app-settings-remove-entry snippet

### DIFF
--- a/app/ns-framework-modules-category/application-settings/basics/basics-page.js
+++ b/app/ns-framework-modules-category/application-settings/basics/basics-page.js
@@ -40,6 +40,11 @@ function onNavigatingTo(args) {
     items.push(new Item("locationX", `${locationX}`));
     console.log(locationX);
     // << app-settings-number-code
+    
+    // >> app-settings-remove-entry
+	// will remove the setting for a key
+	appSettings.remove("keyToRemove");
+    // << app-settings-remove-entry
 
     // >> app-settings-default-value-code
     // will return "No string value" if there is no value for "noSuchKey"


### PR DESCRIPTION
I noticed the "Delete a Value" snippet was missing in the documentation, so I'm proposing to add it. Thanks!