### PR TITLE
Fixing broken link

### DIFF
--- a/app/ns-ui-widgets-category/tab-view/basics/article.md
+++ b/app/ns-ui-widgets-category/tab-view/basics/article.md
@@ -3,4 +3,4 @@ In a NativeScript application, `TabView` has an `items` property which could be 
 XML
 <snippet id='tab-view-basics-xml'/>
 
-> Note: If you have set the `iconSource` property on a `TabViewItem`, but are not seeing any icons next to the title, this might be because the icon is not present in your App_Resources folder. See the [Working with Images]({%slug images#load-images-from-a-resource %}) article for information on how to add and reference your resource images.
+> Note: If you have set the `iconSource` property on a `TabViewItem`, but are not seeing any icons next to the title, this might be because the icon is not present in your App_Resources folder. See the [Working with Images]({%slug image-resources#load-images-from-a-resource %}) article for information on how to add and reference your resource images.


### PR DESCRIPTION
Right now link on https://docs.nativescript.org/ui/ns-ui-widgets/tab-view#title-icon-fonts leads to https://docs.nativescript.org/ui/ns-ui-widgets/true which is a 404. This change references the correct slug & anchor from https://docs.nativescript.org/ui/image-resources (https://github.com/NativeScript/docs/blob/master/docs//ui/image-resources.md)