### PR TITLE
correct imported method name

### DIFF
--- a/app/ns-framework-modules-category/application/ios-notification-observer/ios-notification-observer-ts-page.ts
+++ b/app/ns-framework-modules-category/application/ios-notification-observer/ios-notification-observer-ts-page.ts
@@ -44,7 +44,7 @@ export function onNavigatedTo(args) {
             "batteryLife",
             + (utilsModule.ios.getter(UIDevice, UIDevice.currentDevice).batteryLevel * 100).toFixed(1)
         );
-        observer = application.ios.addNotificationObserver(
+        observer = iosApp.addNotificationObserver(
             UIDeviceBatteryLevelDidChangeNotification,
             notification => {
                 vm.set(
@@ -60,7 +60,7 @@ export function onNavigatedTo(args) {
 export function onUnloaded() {
     if (isIOS) {
         // >> app-ios-observer-remove-ts
-        application.ios.removeNotificationObserver(observer, UIDeviceBatteryLevelDidChangeNotification);
+        iosApp.removeNotificationObserver(observer, UIDeviceBatteryLevelDidChangeNotification);
         // << app-ios-observer-remove-ts
     }
 }


### PR DESCRIPTION
iOS as iosApp is imported  in import { ios as iosApp } from "tns-core-modules/application";
so addNotificationObserver and removeNotificationObserver should be on this member import