### PR TITLE
docs: update shownModally example

### DIFF
--- a/app/main-page.xml
+++ b/app/main-page.xml
@@ -2,7 +2,7 @@
 	<Page.actionBar>
 		<ActionBar title="Cookbook" icon="" class="action-bar" />
 	</Page.actionBar>
-	<StackLayout>
+	<GridLayout>
 		<ListView items="{{ links }}" class="list-group" itemTap="{{ onItemTap }}">
 			<ListView.itemTemplate>
 				<StackLayout class="list-group-item">
@@ -10,5 +10,5 @@
 				</StackLayout>
 			</ListView.itemTemplate>
 		</ListView>
-	</StackLayout>
+	</GridLayout>
 </Page>

--- a/app/ns-ui-category/modal-view/modal-navigation/first-modal-ts-view-page.ts
+++ b/app/ns-ui-category/modal-view/modal-navigation/first-modal-ts-view-page.ts
@@ -6,8 +6,8 @@ export function onNavigate(args) {
     page.frame.navigate("ns-ui-category/modal-view/modal-navigation/second-modal-ts-view-page");
 }
 
-export function onShowingModally(args) {
-    console.log("onShowingModally");
+export function onPageLoaded(args) {
+    console.log("onPageLoaded");
 }
 
 export function onCloseModal(args) {

--- a/app/ns-ui-category/modal-view/modal-navigation/first-modal-ts-view-page.xml
+++ b/app/ns-ui-category/modal-view/modal-navigation/first-modal-ts-view-page.xml
@@ -1,4 +1,4 @@
-<Page backgroundColor="green" showingModally="onShowingModally">
+<Page backgroundColor="green" loaded="onPageLoaded">
     <StackLayout backgroundColor="lightGreen">
         <Button text="Navigate" tap="onNavigate"/>
         <Button text="Close Modal" tap="onCloseModal"/>

--- a/app/ns-ui-category/modal-view/modal-navigation/first-modal-view-page.js
+++ b/app/ns-ui-category/modal-view/modal-navigation/first-modal-view-page.js
@@ -6,10 +6,10 @@ function onNavigate(args) {
 }
 exports.onNavigate = onNavigate;
 
-function onShowingModally(args) {
-    console.log("onShowingModally");
+function onPageLoaded(args) {
+    console.log("onPageLoaded");
 }
-exports.onShowingModally = onShowingModally;
+exports.onPageLoaded = onPageLoaded;
 
 function onCloseModal(args) {
     args.object.closeModal();

--- a/app/ns-ui-category/modal-view/modal-navigation/first-modal-view-page.xml
+++ b/app/ns-ui-category/modal-view/modal-navigation/first-modal-view-page.xml
@@ -1,5 +1,5 @@
 <!-- >> first-modal-view-xml-navigation -->
-<Page backgroundColor="green" showingModally="onShowingModally">
+<Page backgroundColor="green" loaded="onPageLoaded">
     <StackLayout backgroundColor="lightGreen">
         <Button text="Navigate" tap="onNavigate"/>
         <Button text="Close Modal" tap="onCloseModal"/>

--- a/app/ns-ui-category/modal-view/modal-navigation/modal-root.js
+++ b/app/ns-ui-category/modal-view/modal-navigation/modal-root.js
@@ -1,0 +1,13 @@
+exports.onShowingModally = (args) => {
+    // args is of type ShownModallyData
+    console.log(`${args.eventName}`); // showingModally
+};
+
+exports.onShownModally = (args) => {
+    // args is of type ShownModallyData
+    console.log(` ${args.closeCallback}`);
+    console.log(` ${args.context}`);
+    console.log(` ${args.eventName}`);  // shownModally
+    console.log(` ${args.object}`);
+};
+

--- a/app/ns-ui-category/modal-view/modal-navigation/modal-root.xml
+++ b/app/ns-ui-category/modal-view/modal-navigation/modal-root.xml
@@ -1,3 +1,5 @@
 <!-- >> modal-root-xml-navigation -->
-<Frame defaultPage="ns-ui-category/modal-view/modal-navigation/first-modal-view-page"/>
+<Frame defaultPage="ns-ui-category/modal-view/modal-navigation/first-modal-view-page"
+       shownModally="onShownModally" 
+       showingModally="onShowingModally"/>
 <!-- << modal-root-xml-navigation -->

--- a/app/ns-ui-category/modal-view/modal-navigation/modal-ts-root.ts
+++ b/app/ns-ui-category/modal-view/modal-navigation/modal-ts-root.ts
@@ -1,0 +1,15 @@
+import { ShownModallyData } from "tns-core-modules/ui/page";
+
+export function onShowingModally(args: ShownModallyData) {
+    // args is of type ShownModallyData
+    console.log(`${args.eventName}`); // showingModally
+}
+
+export function onShownModally(args: ShownModallyData) {
+    // args is of type ShownModallyData
+    console.log(` ${args.closeCallback}`);
+    console.log(` ${args.context}`);
+    console.log(` ${args.eventName}`);  // shownModally
+    console.log(` ${args.object}`);
+}
+

--- a/app/ns-ui-category/modal-view/modal-navigation/modal-ts-root.xml
+++ b/app/ns-ui-category/modal-view/modal-navigation/modal-ts-root.xml
@@ -1,3 +1,5 @@
 <!-- >> modal-root-xml-navigation-ts -->
-<Frame defaultPage="ns-ui-category/modal-view/modal-navigation/first-modal-ts-view-page"/>
+<Frame defaultPage="ns-ui-category/modal-view/modal-navigation/first-modal-ts-view-page" 
+       shownModally="onShownModally" 
+       showingModally="onShowingModally"/>
 <!-- << modal-root-xml-navigation-ts -->

--- a/package.json
+++ b/package.json
@@ -21,25 +21,22 @@
   "license": "Apache-2.0",
   "nativescript": {
     "id": "org.nativescript.nativescriptsdkexamplesjs",
-    "tns-ios": {
-      "version": "5.3.0-rc-2019-03-25-101854-01"
-    },
     "tns-android": {
-      "version": "5.3.0-rc-2019-03-21-183002-02"
+      "version": "5.4.0-rc-2019-04-02-110853-01"
     }
   },
   "dependencies": {
     "nativescript-theme-core": "~1.0.4",
-    "tns-core-modules": "^5.2.2"
+    "tns-core-modules": "^5.3.1"
   },
   "devDependencies": {
     "eslint": "~5.9.0",
     "fs-extra": "^0.30.0",
     "markdown-snippet-injector": "^0.2.4",
     "nativescript-dev-typescript": "~0.9.0",
-    "nativescript-dev-webpack": "^0.20.3",
+    "nativescript-dev-webpack": "^0.21.0",
     "tar.gz": "^1.0.7",
-    "tns-platform-declarations": "^5.2.2",
+    "tns-platform-declarations": "^5.3.1",
     "tslint": "^5.11.0",
     "typescript": "~3.1.6"
   },


### PR DESCRIPTION
ShownModally and ShowingModally event will fire only on the root modal (e.g. in the navigation example the internal pages won't trigger the modal events - only the root Frame will do).

