### PR TITLE
docs: Add missing closing brackets in demo code

### DIFF
--- a/app/ns-framework-modules-category/image-source/save-image/save-image-page.js
+++ b/app/ns-framework-modules-category/image-source/save-image/save-image-page.js
@@ -59,12 +59,12 @@ function makeCopyFromAsset(args) {
             vm.set("imageAssetCopyPath", path);
             // << (hide)
         }
-    // << image-source-save-from-asset
     })
     .catch((e) => {
         console.log("Error: ");
         console.log(e);
     });
+    // << image-source-save-from-asset
 }
 
 function makeBase64String(args) {

--- a/app/ns-framework-modules-category/image-source/save-image/save-image-ts-page.ts
+++ b/app/ns-framework-modules-category/image-source/save-image/save-image-ts-page.ts
@@ -60,12 +60,12 @@ export function makeCopyFromAsset(args) {
                 vm.set("imageAssetCopyPath", path);
                 // << (hide)
             }
-            // << image-source-save-from-asset-ts
         })
         .catch((e) => {
             console.log("Error: ");
             console.log(e);
         });
+        // << image-source-save-from-asset-ts
 }
 
 export function makeBase64String(args) {


### PR DESCRIPTION
The closing part of the `.then` is (or maybe was rn) missing in the docs. This pr will fix that