### PR TITLE
Fix: Remove duplicates

### DIFF
--- a/app/ns-ui-widgets-category/label/end.md
+++ b/app/ns-ui-widgets-category/label/end.md
@@ -13,7 +13,7 @@ Creating a `Label` programmatically with `text`.
 | `lineHeight`   | `number` | Gets or sets lineHeight style property. |
 | `text`   | `string` | Gets or sets the Label text. |
 | `textAlignment`   | **_"initial"_**, **_"left"_**, **_"center"_**, **_"right"_** | Gets or sets text-alignment style property. |
-| `textDecoration`   | **_"none"_**, **_"underline"_**, **_"line-through"_**, **_"underline"_**, **_"line-through"_** | Gets or sets text swcoration style property. |
+| `textDecoration`   | **_"none"_**, **_"underline"_**, **_"line-through"_** | Gets or sets text swcoration style property. |
 | `textTransform`   | **_"initial"_**, **_"none"_**, **_"capitalize"_**, **_"uppercase"_**, **_"lowercase"_** | Gets or sets text transform style property. |
 | `textWrap`   | `boolean` | Gets or sets whether the Label wraps text or not. |
 | `whiteSpace`   | **_"initial"_**, **_"normal"_**, **_"nowrap"_** | Gets or sets the white space style. |


### PR DESCRIPTION
Under **Properties** the _textDecoration_ lists `underline` and `line-through` twice.

Now it doesn't 😄 